### PR TITLE
Fix documents link path in grow preset

### DIFF
--- a/lib/transform/grow.js
+++ b/lib/transform/grow.js
@@ -75,7 +75,7 @@ const mapGrowLink = async (entry, options) => {
     const file = `${id}.yaml`;
     const func = Object.keys(typeConfig).includes(contentType) ? '!g.doc' : '!g.yaml';
 
-    return `${func} ${path.join(path.relative(process.cwd(), dir), file)}`;
+    return `${func} /${path.join(path.relative(process.cwd(), dir), file)}`;
   }
 
   return '';


### PR DESCRIPTION
In order to be recognized as valid documents, grow needs the leading slash on the documents path.
Otherwise e.g.`partial.path_format` would return `None`