### PR TITLE
Fix imports for grow preset

### DIFF
--- a/lib/transform/grow.js
+++ b/lib/transform/grow.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const yaml = require('../converter/yaml');
 const { getContentTypeDirectory } = require('../utils');
-const { forEachAsync } = require('../array');
+const { mapAsync } = require('../array');
 
 /**
  * Built-in fields carry special meaning that can affect various aspects of building your site.


### PR DESCRIPTION
Require `mapAsync` and remove `forEachAsync` from `array.js`