### PR TITLE
Add Hugo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npx cssg help [command]
 npx cssg init
 ```
 
-Initializes migrations and stores the config values in the `contentful-ssg.config.js` file.
+Initializes contentful-ssg and stores the config values in the `contentful-ssg.config.js` file.
 
 <!-- prettier-ignore -->
 #### Configuration values
@@ -39,8 +39,8 @@ Initializes migrations and stores the config values in the `contentful-ssg.confi
 | environmentId      | `String`             | `'master'`    | Contentful Environment id                                                                                                                                                                                                                                                                                                                                                           |
 | format             | `String`             | `'yaml'`      | File format (currently yaml is the only supported format)                                                                                                                                                                                                                                                                                                                           |
 | directory          | `String`             | `'./content'` | Base directory for content files.                                                                                                                                                                                                                                                                                                                                                   |
-| typeConfig         | `Object`             | `undefined'`  | Pass a map with e.g. grow's blueprint config ({<contenttypeid>: {$path: '...', $view: '...'}})                                                                                                                                                                                                                                                                                      |
-| preset             | `String`             | `undefined'`  | Pass `grow` to enable generator specific addons                                                                                                                                                                                                                                                                                                                                     |
+| typeConfig         | `Object`             | `undefined`   | Pass a map with e.g. grow's blueprint config ({<contenttypeid>: {$path: '...', $view: '...'}})                                                                                                                                                                                                                                                                                      |
+| preset             | `String`             | `undefined`   | Pass `grow` to enable generator specific addons                                                                                                                                                                                                                                                                                                                                     |
 | transform          | `Function`           | `undefined`   | Pass `function(content, { entry, contentType, locale, helper, ... }){...}` to modify the stored object                                                                                                                                                                                                                                                                              |
 | mapDirectory       | `Function`           | `undefined`   | Pass `function(contentType, { locale, helper })` to customize the directory per content-type relative to the base directory.                                                                                                                                                                                                                                                        |
 | mapFilename        | `Function`           | `undefined`   | Pass `function(data, { locale, contentType, entry, format, helper })` to customize the filename per entry                                                                                                                                                                                                                                                                           |
@@ -124,7 +124,7 @@ module.exports = {
 
 ## Can I contribute?
 
-Of course. We appreciate all of our [contributors](https://github.com/jungvonmatt/contentful-migrations/graphs/contributors) and
+Of course. We appreciate all of our [contributors](https://github.com/jungvonmatt/contentful-ssg/graphs/contributors) and
 welcome contributions to improve the project further. If you're uncertain whether an addition should be made, feel
 free to open up an issue and we can discuss it.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,7 +43,7 @@ const getConfig = async (args) => {
 
   let configFileOptions = {};
   try {
-    // get configuration from migrations rc file
+    // get configuration from contentful-ssg rc file
     const explorer = cosmiconfig('contentful-ssg');
     const explorerResult = await explorer.search();
     if (explorerResult !== null) {

--- a/lib/converter/markdown.js
+++ b/lib/converter/markdown.js
@@ -1,5 +1,16 @@
-const convert = () => {
-  throw new Error('Markdown support needs to be implemented!');
+const yaml = require('js-yaml');
+
+/**
+ * Convert object to markdown
+ * @param {Object} obj Source object
+ * @returns {String} Markdown representation of source object
+ */
+const convert = (obj) => {
+  let frontMatter = '';
+  frontMatter += `---\n`;
+  frontMatter += yaml.dump(obj);
+  frontMatter += `---\n`;
+  return frontMatter;
 };
 
 module.exports.convert = convert;


### PR DESCRIPTION
This PR adds a basic Hugo support. 

TBD:
- We could convert the example config (see README) to Hugo presets
- Single (home page, global settings) and repeatable types (pages, headless bundles)
- Different file extensions (Markdown for content, YAML or JSON for data) 