### PR TITLE
fix(mapRichTextNodes): check if node is undefined

### DIFF
--- a/lib/transform/mapper.js
+++ b/lib/transform/mapper.js
@@ -136,6 +136,9 @@ const mapRichTextMarks = (node = []) => {
 
 const mapRichTextNodes = (node, options) => {
   const fieldContent = {};
+  if (typeof node === 'undefined') {
+    return;
+  }
   for (const field of Object.keys(node)) {
     const subNode = node[field];
     switch (field) {


### PR DESCRIPTION
Fixes the TypeError _Cannot convert undefined or null to object_ in `mapRichTextNodes`.