### PR TITLE
Fix: grow preset wrong yaml method

### DIFF
--- a/lib/presets/grow.js
+++ b/lib/presets/grow.js
@@ -27,7 +27,7 @@ const buildInFields = [
 const addBlueprints = async (config) => {
   const { typeConfig, locale } = config || {};
   return mapAsync(Object.entries(typeConfig || {}), async ([contentType, blueprint]) => {
-    const content = await yaml.convert(blueprint);
+    const content = await yaml.stringify(blueprint);
     const dir = await getContentTypeDirectory({ ...config, locale, contentType });
     const filepath = path.join(dir, '_blueprint.yaml');
     await fs.outputFile(filepath, content);


### PR DESCRIPTION
Beim umbenennen der `yaml.convert` Methode vor einigen Monaten, hattest du vergessen, das im `grow` preset anzupassen @bezoerb 

Siehe hier https://github.com/jungvonmatt/contentful-ssg/commit/e87d56ccd6eba78fd208096f4caa70957a3fc6c0#diff-1f7949a7e461ddb37a8623314d9f0beca66676cbfad86f539f3bb23b09d7861eL22-R24

Dieser PR fixed das.