### PR TITLE
fix: exit with error code on errors

### DIFF
--- a/packages/contentful-ssg/README.md
+++ b/packages/contentful-ssg/README.md
@@ -217,6 +217,11 @@ Fetch all content entries and store them as yaml in the configured directory
 npx cssg fetch
 ```
 
+To see all available command line options call
+```bash
+npx cssg help fetch
+```
+
 ## Example configuration
 
 ### Grow

--- a/packages/contentful-ssg/src/cli.ts
+++ b/packages/contentful-ssg/src/cli.ts
@@ -15,15 +15,15 @@ import { omitKeys } from './lib/object.js';
 
 import { getConfig, getEnvironmentConfig } from './lib/config.js';
 import { run } from './index.js';
-import { ContentfulConfig } from './types.js';
+import { Config, ContentfulConfig } from './types.js';
 
 const env = dotenv.config();
 dotenvExpand(env);
 
-const parseArgs = (cmd) => ({
-  environment: cmd.env as string,
+const parseFetchArgs = (cmd): Partial<Config> => ({
   preview: cmd.preview as boolean,
   verbose: cmd.verbose as boolean,
+  ignoreErrors: cmd.ignoreErrors as boolean,
 });
 
 type CommandError = Error & {
@@ -54,7 +54,7 @@ program
   .action(
     actionRunner(async (cmd) => {
       const useTypescript = Boolean(cmd?.typescript ?? false);
-      const config = await getConfig(parseArgs(cmd || {}));
+      const config = await getConfig();
       const verified = await askAll(config);
 
       const environmentConfig = getEnvironmentConfig();
@@ -148,9 +148,10 @@ program
   .description('Fetch content objects')
   .option('-p, --preview', 'Fetch with preview mode')
   .option('-v, --verbose', 'Verbose output')
+  .option('--ignore-errors', 'No error return code when transform has errors')
   .action(
     actionRunner(async (cmd) => {
-      const config = await getConfig(parseArgs(cmd || {}));
+      const config = await getConfig(parseFetchArgs(cmd || {}));
       const verified = await askMissing(config);
 
       return run(verified);

--- a/packages/contentful-ssg/src/index.ts
+++ b/packages/contentful-ssg/src/index.ts
@@ -73,10 +73,7 @@ export const run = async (config: Config): Promise<void> => {
       {
         title: 'Before Hook',
         skip: (ctx) => !ctx.hooks.has('before'),
-        task: async (ctx) => {
-          const result = await ctx.hooks.before();
-          ctx = { ...ctx, ...(result || {}) };
-        },
+        task: async (ctx) => ctx.hooks.before(),
       },
       {
         title: 'Writing files',
@@ -135,12 +132,8 @@ export const run = async (config: Config): Promise<void> => {
       {
         title: 'After Hook',
         skip: (ctx) => !ctx.hooks.has('after'),
-        task: async (ctx) => {
-          const result = await ctx.hooks.after();
-          ctx = { ...ctx, ...(result || {}) };
-        },
+        task: async (ctx) => ctx.hooks.after(),
       },
-
       {
         title: 'Cleanup',
         task: async (ctx) => ctx.fileManager.cleanup(),
@@ -152,4 +145,8 @@ export const run = async (config: Config): Promise<void> => {
   const ctx = await tasks.run();
   await ctx.stats.print();
   console.log('\n---------------------------------------------');
+
+  if (ctx.stats.errors?.length && !config.ignoreErrors) {
+    process.exit(1);
+  }
 };

--- a/packages/contentful-ssg/src/lib/config.ts
+++ b/packages/contentful-ssg/src/lib/config.ts
@@ -122,7 +122,7 @@ export const getEnvironmentConfig = (strict = true): ContentfulConfig =>
  * Get configuration
  * @param {Object} args
  */
-export const getConfig = async (args?: Partial<Config>): Promise<Config> => {
+export const getConfig = async (args: Partial<Config> = {}): Promise<Config> => {
   const defaultOptions: Config = {
     environmentId: 'master',
     host: 'api.contentful.com',

--- a/packages/contentful-ssg/src/types.ts
+++ b/packages/contentful-ssg/src/types.ts
@@ -85,6 +85,7 @@ export type Config = Partial<ContentfulConfig> &
     directory: string;
     managedDirectories?: string[];
     verbose?: boolean;
+    ignoreErrors?: boolean;
     plugins?: Array<[string, KeyValueMap] | PluginInfo | string>;
     resolvedPlugins?: Hooks[];
     preset?: string;


### PR DESCRIPTION
Allow ignoring errors with new "ignoreErrors" setting.
Clean up dead code in hook calls.

Fixes #36 