### PR TITLE
Fix: avoid skipping link entries in menus builder

### DIFF
--- a/packages/cssg-plugin-hugo/index.js
+++ b/packages/cssg-plugin-hugo/index.js
@@ -99,17 +99,22 @@ export default (args) => {
 
   const buildMenu = async (transformContext, runtimeContext, depth = 0) => {
     const { entry, entryMap } = transformContext;
+
+    const getId = (node) => node?.sys?.id;
+    const getContentTypeId = (node) =>
+      node?.sys?.contentType?.sys?.id || entryMap?.get(node?.sys?.id)?.sys?.contentType?.sys?.id;
+
     const entries = entry.fields?.[options.fieldIdMenuEntries] ?? [];
     const nodes = entries
-      .filter((node) => node?.sys?.id)
+      .filter((node) => getId(node) && getContentTypeId(node))
       .map((node, index) => ({
-        identifier: node.sys.id,
+        identifier: getId(node),
         pageRef: getPageRef(transformContext, runtimeContext, node),
         weight: (index + 1) * 10,
         params: {
-          id: node.sys.id,
+          id: getId(node),
           // eslint-disable-next-line camelcase
-          content_type: entryMap.get(node.sys.id).sys.contentType.sys.id,
+          content_type: getContentTypeId(node),
         },
       }));
 

--- a/packages/cssg-plugin-hugo/index.js
+++ b/packages/cssg-plugin-hugo/index.js
@@ -101,7 +101,7 @@ export default (args) => {
     const { entry, entryMap } = transformContext;
     const entries = entry.fields?.[options.fieldIdMenuEntries] ?? [];
     const nodes = entries
-      .filter((node) => node?.sys?.id && node?.sys?.contentType?.sys?.id)
+      .filter((node) => node?.sys?.id)
       .map((node, index) => ({
         identifier: node.sys.id,
         pageRef: getPageRef(transformContext, runtimeContext, node),
@@ -109,7 +109,7 @@ export default (args) => {
         params: {
           id: node.sys.id,
           // eslint-disable-next-line camelcase
-          content_type: node.sys.contentType.sys.id,
+          content_type: entryMap.get(node.sys.id).sys.contentType.sys.id,
         },
       }));
 


### PR DESCRIPTION
This PR fixes missing link type entries in the `menus.yaml`.
If there is an entry of type "link", it will have no `contentType`, which was the reason why it was filtered out in the menu builder. But such entries already got an `id` which is now be used to get the entry from the entries map to provide the actual `contentType`
