### PR TITLE
feat(asset-config): allow reference field configs & configs by naming convention

### DIFF
--- a/packages/cssg-plugin-assets/README.md
+++ b/packages/cssg-plugin-assets/README.md
@@ -20,8 +20,8 @@ You can specify global defaults for ratios and focus areas, defaults per content
       // Use center as default focus area
       default: 'center',
       contentTypes: {
-        'content_type_id': {
-          // Use center as default focus area for content_type_id
+        content_type_id: {
+          // Use top as default focus area for content_type_id
           default: 'top',
           // create overwrites per field
           fields: {
@@ -38,13 +38,13 @@ You can specify global defaults for ratios and focus areas, defaults per content
       default: {square: 1/1, landscape: 16/9},
       // Define overwrites per content-type
       contentTypes: {
-        'media-content-type': {
-          // default ratio for media-content-type should be rectangle ()
+       content_type_id: {
+          // default ratio forcontent_type_id should be rectangle ()
           default: {rectangle: 4/3},
           // create overwrites per field
           fields: {
-            // fieldId in this contentType is generated with original and square derivatives
-            fieldId: {square: 1/1},
+            // field_id in content_type_id is generated with original and square derivatives
+            field_id: {square: 1/1},
           }
         }
       }

--- a/packages/cssg-plugin-assets/README.md
+++ b/packages/cssg-plugin-assets/README.md
@@ -20,13 +20,15 @@ You can specify global defaults for ratios and focus areas, defaults per content
       // Use center as default focus area
       default: 'center',
       contentTypes: {
-        'media-content-type': {
-          // Use center as default focus area for media-content-type
+        'content_type_id': {
+          // Use center as default focus area for content_type_id
           default: 'top',
           // create overwrites per field
           fields: {
-            // Use the largest face detected as focus area for fieldId in media-content-type
-            fieldId: 'face',
+            // Use the largest face detected as focus area for field_id in content_type_id
+            field_id: 'face',
+            // use the value from field custom_focus_area in content_type_id
+            alt_field_id: 'field:custom_focus_area'
           }
         }
       }
@@ -111,7 +113,6 @@ plugins: [
 
 ## Options
 
-
 | Name                 | Type       | Default                        | Description                                                                                                                                                                  |
 | -------------------- | ---------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | download             | `boolean`  | `false`                        | Download assets to bypass the contentful cdn on your production site.                                                                                                        |
@@ -143,7 +144,15 @@ plugins: [
       cacheFolder: '.cache',
       extraTypes: ['image/webp'],
       ratios: { default: { square: 1 / 1, portrait: 3 / 4, landscape: 16 / 9 } },
-      focusAreas: { default: 'face' },
+      focusAreas: {
+        default: 'face',
+        contentTypes: {
+          c_media: {
+            mobile_src: 'field:mobile_focus_area',
+            desktop_src: 'field:desktop_focus_area',
+          },
+        },
+      },
     },
   },
 ];

--- a/packages/cssg-plugin-assets/README.md
+++ b/packages/cssg-plugin-assets/README.md
@@ -27,7 +27,7 @@ You can specify global defaults for ratios and focus areas, defaults per content
           fields: {
             // Use the largest face detected as focus area for field_id in content_type_id
             field_id: 'face',
-            // use the value from field custom_focus_area in content_type_id
+            // Use the value from field custom_focus_area in content_type_id
             alt_field_id: 'field:custom_focus_area'
           }
         }

--- a/packages/cssg-plugin-assets/README.md
+++ b/packages/cssg-plugin-assets/README.md
@@ -144,15 +144,18 @@ plugins: [
       cacheFolder: '.cache',
       extraTypes: ['image/webp'],
       ratios: { default: { square: 1 / 1, portrait: 3 / 4, landscape: 16 / 9 } },
-      focusAreas: {
-        default: 'face',
-        contentTypes: {
-          c_media: {
-            mobile_src: 'field:mobile_focus_area',
-            desktop_src: 'field:desktop_focus_area',
+     focusAreas: {
+          default: 'face',
+          contentTypes: {
+            c_media: {
+              default: 'center',
+              fields: {
+                mobile_src: 'field:mobile_focus_area',
+                desktop_src: 'field:desktop_focus_area',
+              },
+            }
           },
         },
-      },
     },
   },
 ];

--- a/packages/cssg-plugin-assets/README.md
+++ b/packages/cssg-plugin-assets/README.md
@@ -23,7 +23,7 @@ You can specify global defaults for ratios and focus areas, defaults per content
         content_type_id: {
           // Use top as default focus area for content_type_id
           default: 'top',
-          // create overwrites per field
+          // Create overwrites per field
           fields: {
             // Use the largest face detected as focus area for field_id in content_type_id
             field_id: 'face',
@@ -34,14 +34,14 @@ You can specify global defaults for ratios and focus areas, defaults per content
       }
     },
     ratios: {
-      // square and landscape derivatives when nothing else is specified. The 'original' ratio is always available.
+      // Square and landscape derivatives when nothing else is specified. The 'original' ratio is always available.
       default: {square: 1/1, landscape: 16/9},
       // Define overwrites per content-type
       contentTypes: {
        content_type_id: {
-          // default ratio forcontent_type_id should be rectangle ()
+          // Default ratio forcontent_type_id should be rectangle ()
           default: {rectangle: 4/3},
-          // create overwrites per field
+          // Create overwrites per field
           fields: {
             // field_id in content_type_id is generated with original and square derivatives
             field_id: {square: 1/1},

--- a/packages/cssg-plugin-assets/src/helper/image.test.ts
+++ b/packages/cssg-plugin-assets/src/helper/image.test.ts
@@ -34,6 +34,13 @@ describe('getFocusArea', () => {
     expect(focusArea).toEqual('center');
   });
 
+  test('backwards compatibility', async () => {
+    const transformContext = await getTransformContextMock({ focus_area: 'face' });
+    const focusArea = getFocusArea(transformContext, {});
+
+    expect(focusArea).toEqual('face');
+  });
+
   test('media_focus_area field', async () => {
     const transformContext = await getTransformContextMock({ media_focus_area: 'top' });
     const focusArea = getFocusArea(transformContext, {});

--- a/packages/cssg-plugin-assets/src/helper/image.test.ts
+++ b/packages/cssg-plugin-assets/src/helper/image.test.ts
@@ -1,0 +1,189 @@
+import { Asset } from '@jungvonmatt/contentful-ssg';
+import { mapAssetLink } from '@jungvonmatt/contentful-ssg/mapper/map-reference-field';
+import { localizeEntry } from '@jungvonmatt/contentful-ssg/tasks/localize';
+import {
+  getContent,
+  getRuntimeContext,
+  getTransformContext,
+} from '@jungvonmatt/contentful-ssg/__test__/mock';
+
+import { EntryConfig, PluginConfig } from '../types.js';
+
+import { getRatioConfig, getFocusArea } from './image.js';
+
+const getTransformContextMock = async (fields: Record<string, string> = {}) => {
+  const content = await getContent();
+  const runtimeContext = getRuntimeContext();
+  const entry = localizeEntry(content.entry, 'en-US', runtimeContext.data);
+
+  entry.sys.contentType.sys.id = 'ct';
+
+  const transformContext = getTransformContext({
+    entry: { ...entry, fields },
+    fieldId: 'media',
+  });
+
+  return transformContext;
+};
+
+describe('getFocusArea', () => {
+  test('default', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {});
+
+    expect(focusArea).toEqual('center');
+  });
+
+  test('media_focus_area field', async () => {
+    const transformContext = await getTransformContextMock({ media_focus_area: 'top' });
+    const focusArea = getFocusArea(transformContext, {});
+
+    expect(focusArea).toEqual('top');
+  });
+
+  test('configured field - default', async () => {
+    const transformContext = await getTransformContextMock({ reference: 'bottom' });
+    const focusArea = getFocusArea(transformContext, { default: 'field:reference' });
+
+    expect(focusArea).toEqual('bottom');
+  });
+
+  test('configured field - content-type default', async () => {
+    const transformContext = await getTransformContextMock({ a: 'bottom', b: 'right' });
+    const focusArea = getFocusArea(transformContext, {
+      default: 'field:a',
+      contentTypes: { ct: { default: 'field:b' } },
+    });
+
+    expect(focusArea).toEqual('right');
+  });
+
+  test('configured field - content-type fieldId', async () => {
+    const transformContext = await getTransformContextMock({
+      a: 'bottom',
+      b: 'right',
+      c: 'top_right',
+    });
+    const focusArea = getFocusArea(transformContext, {
+      default: 'field:a',
+      contentTypes: { ct: { default: 'field:b', fields: { media: 'field:c' } } },
+    });
+
+    expect(focusArea).toEqual('top_right');
+  });
+
+  test('field by naming convention', async () => {
+    const transformContext = await getTransformContextMock({
+      a: 'bottom',
+      b: 'right',
+      media_focus_area: 'top_left',
+    });
+    const focusArea = getFocusArea(transformContext, {
+      default: 'field:a',
+      contentTypes: { ct: { default: 'field:b', fields: { media: 'top' } } },
+    });
+
+    expect(focusArea).toEqual('top_left');
+  });
+
+  test('config default', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      default: 'bottom',
+    });
+
+    expect(focusArea).toEqual('bottom');
+  });
+
+  test('config content-type default', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      default: 'top_left',
+      contentTypes: { ct: { default: 'top_right' } },
+    });
+
+    expect(focusArea).toEqual('top_right');
+  });
+
+  test('config field', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      default: 'top_left',
+      contentTypes: { ct: { default: 'top_right', fields: { media: 'top' } } },
+    });
+
+    expect(focusArea).toEqual('top');
+  });
+
+  test('config field fallback ct', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      default: 'top_left',
+      contentTypes: { ct: { default: 'top_right', fields: { media: 'field:b' } } },
+    });
+
+    expect(focusArea).toEqual('top_right');
+  });
+
+  test('config field fallback default', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      default: 'top_left',
+      contentTypes: { ct: { default: 'field:a', fields: { media: 'field:b' } } },
+    });
+
+    expect(focusArea).toEqual('top_left');
+  });
+
+  test('config field fallback center', async () => {
+    const transformContext = await getTransformContextMock();
+    const focusArea = getFocusArea(transformContext, {
+      contentTypes: { ct: { default: 'field:a', fields: { media: 'field:b' } } },
+    });
+
+    expect(focusArea).toEqual('center');
+  });
+});
+
+describe('getRatioConfig', () => {
+  test('empty', async () => {
+    const transformContext = await getTransformContextMock();
+    const c = undefined;
+    const ratios = getRatioConfig(transformContext, c);
+
+    expect(ratios).toEqual({});
+  });
+
+  test('default', async () => {
+    const transformContext = await getTransformContextMock();
+    const ratios = getRatioConfig(transformContext, {
+      default: { square: 1 },
+    });
+
+    expect(ratios).toEqual({ square: 1 });
+  });
+
+  test('ct default', async () => {
+    const transformContext = await getTransformContextMock();
+    const ratios = getRatioConfig(transformContext, {
+      default: { square: 1 },
+      contentTypes: {
+        ct: { default: { rect: 4 / 3 } },
+      },
+    });
+
+    expect(ratios).toEqual({ rect: 4 / 3 });
+  });
+
+  test('field default', async () => {
+    const transformContext = await getTransformContextMock();
+    const ratios = getRatioConfig(transformContext, {
+      default: { square: 1 },
+      contentTypes: {
+        ct: { default: { rect: 4 / 3 }, fields: { media: { portrait: 2 / 3 } } },
+      },
+    });
+
+    expect(ratios).toEqual({ portrait: 2 / 3 });
+  });
+});

--- a/packages/cssg-plugin-assets/src/helper/image.ts
+++ b/packages/cssg-plugin-assets/src/helper/image.ts
@@ -53,6 +53,7 @@ export const getFocusArea = (
   const fallback =
     (!contentTypeDefaultConfig?.startsWith('field:') && (contentTypeDefaultConfig as FocusArea)) ||
     (!defaultConfig?.startsWith('field:') && (defaultConfig as FocusArea)) ||
+    (entry?.fields?.focus_area as FocusArea) ||
     'center';
 
   if (Object.keys(entry.fields).includes(referenceFieldId)) {

--- a/packages/cssg-plugin-assets/src/index.test.ts
+++ b/packages/cssg-plugin-assets/src/index.test.ts
@@ -1,3 +1,5 @@
+import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
+import { Asset } from '@jungvonmatt/contentful-ssg';
 import { mapAssetLink } from '@jungvonmatt/contentful-ssg/mapper/map-reference-field';
 import { localizeEntry } from '@jungvonmatt/contentful-ssg/tasks/localize';
 import {
@@ -5,7 +7,6 @@ import {
   getRuntimeContext,
   getTransformContext,
 } from '@jungvonmatt/contentful-ssg/__test__/mock';
-import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
 import { existsSync } from 'fs';
 import { remove } from 'fs-extra';
 import got from 'got';
@@ -48,7 +49,7 @@ const getMockData = async (type) => {
   const runtimeContext = getRuntimeContext();
   const entry = localizeEntry(content.entry, 'en-US', runtimeContext.data);
   const asset = localizeEntry(
-    content.assets.find((asset) => asset?.fields?.file?.['en-US']?.contentType === type),
+    content.assets.find((asset) => asset?.fields?.file?.['en-US']?.contentType === type) as Asset,
     'en-US',
     runtimeContext.data
   );
@@ -238,10 +239,10 @@ describe('cssg-plugin-assets', () => {
     const fileName = basename(`${result.src.replace(/\.\w+$/, '')}-poster.jpg`);
 
     expect(result.mimeType).toEqual('video/mp4');
-    expect(basename(result.poster)).toEqual(fileName);
+    expect(basename(result?.poster ?? '')).toEqual(fileName);
 
-    expect(existsSync(join(cacheFolder, result.poster))).toBe(true);
-    expect(existsSync(join(assetFolder, result.poster))).toBe(true);
+    expect(existsSync(join(cacheFolder, result?.poster ?? ''))).toBe(true);
+    expect(existsSync(join(assetFolder, result?.poster ?? ''))).toBe(true);
 
     await remove(cacheFolder);
     await remove(assetFolder);
@@ -270,11 +271,12 @@ describe('cssg-plugin-assets', () => {
     const fileName = basename(`${result.src.replace(/\.\w+$/, '')}-poster.jpg`);
 
     expect(result.mimeType).toEqual('video/mp4');
-    expect(basename(result.poster)).toEqual(fileName);
+    expect(basename(result?.poster ?? '')).toEqual(fileName);
 
-    expect(existsSync(join(cacheFolder, result.poster))).toBe(true);
-    expect(existsSync(join(assetFolder, result.poster))).toBe(true);
+    expect(existsSync(join(cacheFolder, result?.poster ?? ''))).toBe(true);
+    expect(existsSync(join(assetFolder, result?.poster ?? ''))).toBe(true);
 
+    // @ts-ignore
     const mock = mockedCreateFFmpeg.getMockImplementation()();
     expect(mock.run).toHaveBeenCalledWith(
       '-i',
@@ -327,7 +329,7 @@ describe('cssg-plugin-assets', () => {
 
     const instance = plugin();
     const result = (await instance.mapAssetLink(
-      { ...transformContext, asset: null },
+      { ...transformContext, asset: undefined },
       runtimeContext,
       defaultValue
     )) as ProcessedSvg;

--- a/packages/cssg-plugin-assets/src/types.ts
+++ b/packages/cssg-plugin-assets/src/types.ts
@@ -2,6 +2,7 @@ import { Asset, MapAssetLink, TransformContext } from '@jungvonmatt/contentful-s
 import { Plugin } from 'svgo';
 
 export type Ratios = Record<string, number>;
+export type FocusAreaReference = `field:${string}`;
 export type FocusArea =
   | 'center'
   | 'top'
@@ -15,27 +16,22 @@ export type FocusArea =
   | 'face'
   | 'faces';
 
-export type RatioConfig = {
-  default?: Ratios;
+export type EntryConfig<T = any> = {
+  default?: T;
   contentTypes?: Record<
     string,
     {
-      default?: Ratios;
-      fields?: Record<string, Ratios>;
+      default?: T;
+      fields?: Record<string, T>;
     }
   >;
 };
 
-export type FocusAreaConfig = {
-  default?: FocusArea;
-  contentTypes?: Record<
-    string,
-    {
-      default?: FocusArea;
-      fields?: Record<string, FocusArea>;
-    }
-  >;
-};
+export type EntryConfigKey = keyof Pick<PluginConfig, 'ratios' | 'focusAreas'>;
+
+export type RatioConfig = EntryConfig<Ratios>;
+
+export type FocusAreaConfig = EntryConfig<FocusArea | FocusAreaReference>;
 
 export type SizesCallback = (asset: Asset, ratio: number, focusArea: string) => number;
 


### PR DESCRIPTION
## Feature

Take the `focus_area` field will just be implemented for backwards compatibility reasons.
There are two new config alternatives:

A) Create a **field_id**_focus_area field 
e.g.

**Field:** media = ASSET
**Field:** media_focus_area = 'face'

B) Configure the field in the plugin config by prefixing the value with `field:`

```
 {
  ...
  focusAreas: { default: 'field:mobile_focus_area' }
  ...
 }
```

See [tests](https://github.com/jungvonmatt/contentful-ssg/pull/51/files#diff-08b3d9cf309062268bf33e9929da8b3cde40ffc59e0517558dc9270c9e1a25baR46) for more examples