### PR TITLE
fix: remove deprecated custom lang param

### DIFF
--- a/packages/cssg-plugin-hugo/index.js
+++ b/packages/cssg-plugin-hugo/index.js
@@ -286,12 +286,10 @@ export default (args) => {
             const { code, name: languageName } = locale;
 
             const languageCode = code;
-            const [languageNameShort] = languageCode.split('-');
 
             const localeConfig = {
               languageCode,
               languageName,
-              languageNameShort,
               weight: locale.default ? 1 : 2,
             };
 


### PR DESCRIPTION
`languageNameShort` is used as a custom param in the generated **languages.yaml**. This is no longer permitted. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

The PR solves the following deprecation error

> ERROR deprecated: config: languages.en.languagenameshort: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.128.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

Related issue: #62